### PR TITLE
Improve responsive layout

### DIFF
--- a/basederecepciones.html
+++ b/basederecepciones.html
@@ -26,7 +26,7 @@ style="background-image: url('resources/images/background.png'); background-size
   </a>
 </button>
 
-<main class="mx-auto py-8 flex-1 w-full glass rounded-lg">
+<main class="mx-auto py-8 flex-1 w-full max-w-screen-lg px-4 glass rounded-lg">
 
     <script>
   const airtableApiKey = 'pattDSGqrGM8UN6IE.62fba30353b35df97342a727eae2fd37e7492a99319c77b595b28e615dac7ed5';
@@ -74,15 +74,15 @@ style="background-image: url('resources/images/background.png'); background-size
   });
 </script>
 
-<div class="glass grid grid-cols-4 gap-4 p-6">
+<div class="glass grid grid-cols-1 lg:grid-cols-4 gap-4 p-6">
 
   <!-- Div 1: ocupa 2 columnas -->
-  <div class="col-span-3 glass p-6 rounded shadow">
+  <div class="lg:col-span-3 glass p-6 rounded shadow">
         <iframe class="airtable-embed" src="https://airtable.com/embed/appA9OW9ZVGe7YYaT/shruy0iVOZDlSv04N" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
   </div>
 
   <!-- Div 2: ocupa 1 columna -->
-  <div class="glass p-6 rounded shadow">
+  <div class="lg:col-span-1 glass p-6 rounded shadow">
     <iframe class="airtable-embed" src="https://form.jotform.com/251711318527050" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
   </div>
 

--- a/graficosderecepcion.html
+++ b/graficosderecepcion.html
@@ -26,7 +26,7 @@ style="background-image: url('resources/images/background.png'); background-size
   </a>
 </button>
 
-    <main class="mx-auto py-8 flex-1 w-full glass rounded-lg">
+    <main class="mx-auto py-8 flex-1 w-full max-w-screen-lg px-4 glass rounded-lg">
 
 <!--contenido grafico-->
         <div class="rounded-xl shadow-lg glass-card p-4">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gray-100 text-gray-900 flex flex-col min-h-screen overflow-hidden" 
 style="background-image: url('resources/images/background.png'); background-size: cover; background-position: center;">
-    <main class="mx-auto py-8 flex-1 w-full glass rounded-lg">
+    <main class="mx-auto py-8 flex-1 w-full max-w-screen-lg px-4 glass rounded-lg">
 <!-- Solo el bloque del nav, el resto igual -->
 <nav class="relative mt-8 glass px-4 py-2 rounded-lg shadow-lg">
     <div class="max-w-6xl mx-auto flex justify-center items-center h-8 relative">
@@ -33,15 +33,15 @@ style="background-image: url('resources/images/background.png'); background-size
     </div>
 </nav>
 <!-- Contenido dinámico -->
-    <div id="content-inicio" class="tab-content glass p-6 rounded-lg align-left ml-4 md:ml-8 lg:ml-32 mt-16 md:mt-32 lg:mt-64">
-    <h2 class="text-6xl boldonse-regular mb-4 text-left w-screen pr-8 ">Bienvenido a Vergaser PROIASA</h2>
+    <div id="content-inicio" class="tab-content glass p-6 rounded-lg mt-16 sm:mt-32 lg:mt-64 mx-auto max-w-screen-lg">
+    <h2 class="text-6xl boldonse-regular mb-4 text-left">Bienvenido a Vergaser PROIASA</h2>
         <p>Contenido de la página de inicio.</p>
     </div>
 
-    <div id="content-analisis" class="tab-content glass p-6 hidden mt-12 rounded-lg">
-        <div class="grid grid-cols-4 gap-1 justify-center">
+    <div id="content-analisis" class="tab-content glass p-6 hidden mt-12 rounded-lg max-w-screen-lg mx-auto">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 justify-center">
 
-    <div class="relative flex w-80 flex-col rounded-xl glass-card text-gray-700 shadow-md">
+    <div class="relative flex w-full flex-col rounded-xl glass-card text-gray-700 shadow-md">
         <div class="relative mx-4 -mt-6 overflow-hidden rounded-xl bg-blue-gray-500 bg-clip-border text-white shadow-lg shadow-blue-gray-500/40 bg-gradient-to-r from-blue-500 to-blue-600">
             <img src="resources/images/tallerbannercard.png" alt="Analisis de Recepciones" class="w-full h-full object-cover">
     </div>
@@ -60,7 +60,7 @@ style="background-image: url('resources/images/background.png'); background-size
     </div>
     </div>
 
-    <div class="relative flex w-80 flex-col rounded-xl glass-card text-gray-700 shadow-md">
+    <div class="relative flex w-full flex-col rounded-xl glass-card text-gray-700 shadow-md">
         <div class="relative mx-4 -mt-6 overflow-hidden rounded-xl bg-blue-gray-500 bg-clip-border text-white shadow-lg shadow-blue-gray-500/40 bg-gradient-to-r from-blue-500 to-blue-600">
             <img src="resources/images/tallerbannercard.png" alt="Analisis de Recepciones" class="w-full h-full object-cover">
     </div>
@@ -79,7 +79,7 @@ style="background-image: url('resources/images/background.png'); background-size
     </div>
     </div>
 
-    <div class="relative flex w-80 flex-col rounded-xl glass-card text-gray-700 shadow-md">
+    <div class="relative flex w-full flex-col rounded-xl glass-card text-gray-700 shadow-md">
         <div class="relative mx-4 -mt-6 overflow-hidden rounded-xl bg-blue-gray-500 bg-clip-border text-white shadow-lg shadow-blue-gray-500/40 bg-gradient-to-r from-blue-500 to-blue-600">
             <img src="resources/images/tallerbannercard.png" alt="Analisis de Recepciones" class="w-full h-full object-cover">
     </div>
@@ -98,7 +98,7 @@ style="background-image: url('resources/images/background.png'); background-size
     </div>
     </div>
 
-    <div class="relative flex w-80 flex-col rounded-xl glass-card text-gray-700 shadow-md">
+    <div class="relative flex w-full flex-col rounded-xl glass-card text-gray-700 shadow-md">
         <div class="relative mx-4 -mt-6 overflow-hidden rounded-xl bg-blue-gray-500 bg-clip-border text-white shadow-lg shadow-blue-gray-500/40 bg-gradient-to-r from-blue-500 to-blue-600">
             <img src="resources/images/tallerbannercard.png" alt="Analisis de Recepciones" class="w-full h-full object-cover">
     </div>
@@ -121,13 +121,13 @@ style="background-image: url('resources/images/background.png'); background-size
 
     </div>
 
-    <div id="content-formularios" class="tab-content glass p-6 hidden rounded-lg">
+    <div id="content-formularios" class="tab-content glass p-6 hidden rounded-lg max-w-screen-lg mx-auto">
         <h2 class="text-2xl font-bold mb-4">Formularios</h2>
         <p>Contenido de formularios.</p>
     </div>
     
-    <div id="content-accesos" class="tab-content glass p-6 hidden rounded-lg">
-        <div class="grid gap-4 mx-auto mt-12" style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); max-width: calc(6 * 200px);">
+    <div id="content-accesos" class="tab-content glass p-6 hidden rounded-lg max-w-screen-lg mx-auto">
+        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mx-auto mt-12 max-w-screen-lg">
               <!-- Card 1 -->
         <div class=" glass-card rounded-xl shadow-lg overflow-hidden flex flex-col">
             <!-- Imagen -->
@@ -139,7 +139,7 @@ style="background-image: url('resources/images/background.png'); background-size
             <h3 class="text-lg font-semibold text-gray-800 mb-2">Ordenes de recepción</h3>
             <p class="text-gray-600 text-sm">Ver y editar registros de ordenes de recepción</p>
             <br>
-            <a href="basederecepciones.html" class="mt-auto inline-block w-1/4 rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors">
+            <a href="basederecepciones.html" class="mt-auto inline-block w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition-colors text-center">
                 editar
             </a>
             </div>


### PR DESCRIPTION
## Summary
- make dashboard containers responsive
- adjust analysis and access grids for small screens
- tweak layout of reception and charts pages

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ecfaf0f24832abc45389e07e3dee0