### PR TITLE
Fix Pyodide results parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,9 @@ async function runAnovaPy(groups) {
     const pyodide = await initPyodide;
     pyodide.globals.set('groups', groups);
     await pyodide.runPythonAsync('result = run_anova(groups)');
-    const result = pyodide.globals.get('result').toJs();
+    const result = pyodide.globals
+        .get('result')
+        .toJs({ dict_converter: Object.fromEntries });
     pyodide.globals.delete('result');
     pyodide.globals.delete('groups');
     return result;


### PR DESCRIPTION
## Summary
- convert Python results to plain JS objects so group statistics render correctly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687da9f0b2ac832ab14ef78ec74bb2bc