### PR TITLE
Add treatment stats to ANOVA output

### DIFF
--- a/anova.py
+++ b/anova.py
@@ -30,3 +30,55 @@ def run_anova(groups_js):
         'F0': F0,
         'p_value': p_value,
     }
+
+
+def calculos_por_tratamiento(observaciones):
+    """Calcula estadísticas básicas a partir de las observaciones."""
+
+    # Datos de observaciones por tratamiento (método de ensamble)
+
+    # Paso 1: Calcular el total por tratamiento (Yi·)
+    totales_por_tratamiento = {
+        k: sum(v) for k, v in observaciones.items()
+    }
+
+    # Paso 2: Calcular el número de datos por tratamiento (ni)
+    n_por_tratamiento = {
+        k: len(v) for k, v in observaciones.items()
+    }
+
+    # Paso 3: Calcular la media muestral por tratamiento (Ȳi)
+    medias_por_tratamiento = {
+        k: sum(v) / len(v) for k, v in observaciones.items()
+    }
+
+    # Paso 4: Calcular la suma total de los datos (Y..)
+    total_general = sum(sum(v) for v in observaciones.values())
+
+    # Paso 5: Calcular el número total de observaciones (N)
+    N = sum(len(v) for v in observaciones.values())
+
+    # Paso 6: Calcular la media global (Ȳ..)
+    media_global = total_general / N
+
+    # Paso 7: Calcular las desviaciones respecto a la media global (τ̂i)
+    desviaciones_respecto_media_global = {
+        k: medias_por_tratamiento[k] - media_global
+        for k in observaciones
+    }
+
+    # Paso 8: Calcular la suma de los cuadrados de todos los datos
+    suma_cuadrados_total = sum(
+        y ** 2 for grupo in observaciones.values() for y in grupo
+    )
+
+    return {
+        'totales_por_tratamiento': totales_por_tratamiento,
+        'n_por_tratamiento': n_por_tratamiento,
+        'medias_por_tratamiento': medias_por_tratamiento,
+        'total_general': total_general,
+        'N': N,
+        'media_global': media_global,
+        'desviaciones_respecto_media_global': desviaciones_respecto_media_global,
+        'suma_cuadrados_total': suma_cuadrados_total,
+    }

--- a/index.html
+++ b/index.html
@@ -109,10 +109,26 @@ async function runAnovaPy(groups) {
     const pyodide = await initPyodide;
     pyodide.globals.set('groups', groups);
     await pyodide.runPythonAsync('result = run_anova(groups)');
-    const result = pyodide.globals.get('result').toJs();
+    const result = pyodide.globals
+        .get('result')
+        .toJs({ dict_converter: Object.fromEntries });
     pyodide.globals.delete('result');
     pyodide.globals.delete('groups');
     return result;
+}
+
+async function runCalculosPy(groups) {
+    const pyodide = await initPyodide;
+    pyodide.globals.set('observaciones', groups);
+    await pyodide.runPythonAsync(
+        'calcs = calculos_por_tratamiento(observaciones)'
+    );
+    const calcs = pyodide.globals
+        .get('calcs')
+        .toJs({ dict_converter: Object.fromEntries });
+    pyodide.globals.delete('calcs');
+    pyodide.globals.delete('observaciones');
+    return calcs;
 }
 
 document.getElementById('runAnova').addEventListener('click', async function() {
@@ -135,6 +151,7 @@ document.getElementById('runAnova').addEventListener('click', async function() {
     }
 
     const result = await runAnovaPy(groups);
+    const calcs = await runCalculosPy(groups);
     const groupMeans = result.group_means;
 
     let html = '<h2 class="font-semibold mb-2">Promedios</h2>';
@@ -144,6 +161,22 @@ document.getElementById('runAnova').addEventListener('click', async function() {
         html += `<tr><td>${g}</td><td>${groupMeans[g].toFixed(4)}</td></tr>`;
     });
     html += '</tbody></table>';
+
+    html += '<h2 class="font-semibold mb-2">Estadísticas por tratamiento</h2>';
+    html += '<table class="mb-4 min-w-full text-sm text-center"><thead><tr>';
+    html += '<th>Tratamiento</th><th>Yi·</th><th>ni</th><th>Ȳi</th><th>τ̂i</th></tr></thead><tbody>';
+    Object.keys(calcs.totales_por_tratamiento).forEach(g => {
+        html += `<tr><td>${g}</td><td>${calcs.totales_por_tratamiento[g]}</td>` +
+            `<td>${calcs.n_por_tratamiento[g]}</td>` +
+            `<td>${calcs.medias_por_tratamiento[g].toFixed(4)}</td>` +
+            `<td>${calcs.desviaciones_respecto_media_global[g].toFixed(4)}</td></tr>`;
+    });
+    html += '</tbody></table>';
+
+    html += `<p><strong>Y..</strong>: ${calcs.total_general}</p>`;
+    html += `<p><strong>N</strong>: ${calcs.N}</p>`;
+    html += `<p><strong>Ȳ..</strong>: ${calcs.media_global.toFixed(4)}</p>`;
+    html += `<p><strong>Suma de cuadrados total</strong>: ${calcs.suma_cuadrados_total.toFixed(4)}</p>`;
 
     html += '<table class="min-w-full text-sm text-center">';
     html += '<thead><tr><th>FV</th><th>SC</th><th>GL</th><th>CM</th><th>F0</th><th>Valor-p</th></tr></thead><tbody>';


### PR DESCRIPTION
## Summary
- add `runCalculosPy` helper to fetch per-treatment statistics
- render treatment totals, counts, means, deviations and global values in results table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687da9f0b2ac832ab14ef78ec74bb2bc