### PR TITLE
Fix Pyodide input handling

### DIFF
--- a/anova.py
+++ b/anova.py
@@ -42,8 +42,17 @@ def run_anova(groups_js):
     }
 
 
-def calculos_por_tratamiento(observaciones):
-    """Calcula estadísticas básicas a partir de las observaciones."""
+def calculos_por_tratamiento(observaciones_js):
+    """Calcula estadísticas básicas a partir de las observaciones.
+
+    The input may come from JavaScript via Pyodide, in which case it will be a
+    ``JsProxy``.  Handle both that and regular Python ``dict`` input.
+    """
+
+    try:
+        observaciones = observaciones_js.to_py()
+    except AttributeError:
+        observaciones = observaciones_js
 
     # Datos de observaciones por tratamiento (método de ensamble)
 


### PR DESCRIPTION
## Summary
- handle JsProxy input for per-treatment calculations

## Testing
- `python3 - <<'PY'
from anova import calculos_por_tratamiento
print(calculos_por_tratamiento({'A':[1,2], 'B':[3,4]}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687db0345f6c832a92f191d1f7985277