### PR TITLE
Add Duncan method

### DIFF
--- a/anova.py
+++ b/anova.py
@@ -237,3 +237,67 @@ def calcular_tukey(observaciones_js, alpha=0.05):
         'q_crit': q_crit,
         'comparaciones': comparaciones,
     }
+
+
+def calcular_duncan(observaciones_js, alpha=0.05):
+    """Realiza la prueba de comparaciones múltiples de Duncan.
+
+    Parameters
+    ----------
+    observaciones_js : dict or JsProxy
+        Mapeo de tratamientos a listas de observaciones.
+    alpha : float, optional
+        Nivel de significancia utilizado para obtener el valor crítico
+        de la distribución del rango studentizado. Por defecto 0.05.
+
+    Returns
+    -------
+    dict
+        Información de las comparaciones por pares. Para cada par de grupos se
+        indican la diferencia absoluta de medias, el error estándar, el valor
+        crítico *q*, la DMS calculada y si la diferencia es significativa.
+    """
+
+    from itertools import combinations
+    from math import sqrt
+    from scipy import stats
+
+    try:
+        observaciones = observaciones_js.to_py()
+    except AttributeError:
+        observaciones = observaciones_js
+
+    anova_res = run_anova(observaciones)
+    medias = anova_res['group_means']
+    n_por_tratamiento = {k: len(v) for k, v in observaciones.items()}
+    cm_error = anova_res['CM_E']
+    gl_error = anova_res['GL_E']
+
+    # Ordenar los grupos por su media para calcular el rango apropiado
+    ordenados = sorted(medias.items(), key=lambda x: x[1])
+    orden = [g for g, _ in ordenados]
+
+    comparaciones = {}
+    for i in range(len(orden)):
+        for j in range(i + 1, len(orden)):
+            g1 = orden[i]
+            g2 = orden[j]
+            diff = abs(medias[g1] - medias[g2])
+            r = j - i + 1
+            q_crit = stats.studentized_range.ppf(1 - alpha, r, gl_error)
+            se = sqrt(cm_error / 2 * (1 / n_por_tratamiento[g1] + 1 / n_por_tratamiento[g2]))
+            dms = q_crit * se
+            comparaciones[f"{g1}-{g2}"] = {
+                'grupo1': g1,
+                'grupo2': g2,
+                'diff': diff,
+                'se': se,
+                'q_crit': q_crit,
+                'dms': dms,
+                'rango': r,
+                'significant': diff >= dms,
+            }
+
+    return {
+        'comparaciones': comparaciones,
+    }

--- a/index.html
+++ b/index.html
@@ -179,6 +179,18 @@ async function runTukeyPy(groups) {
     return tukeyRes;
 }
 
+async function runDuncanPy(groups) {
+    const pyodide = await initPyodide;
+    pyodide.globals.set('duncan_groups', groups);
+    await pyodide.runPythonAsync('duncan_res = calcular_duncan(duncan_groups)');
+    const duncanRes = pyodide.globals
+        .get('duncan_res')
+        .toJs({ dict_converter: Object.fromEntries });
+    pyodide.globals.delete('duncan_res');
+    pyodide.globals.delete('duncan_groups');
+    return duncanRes;
+}
+
 
 document.getElementById('runAnova').addEventListener('click', async function() {
     const rows = document.querySelectorAll('#dataTable tbody tr');
@@ -203,6 +215,7 @@ document.getElementById('runAnova').addEventListener('click', async function() {
     const calcs = await runCalculosPy(groups);
     const lsd = await runLsdPy(groups);
     const tukey = await runTukeyPy(groups);
+    const duncan = await runDuncanPy(groups);
     const groupMeans = result.group_means;
 
     let html = '<h2 class="font-semibold mb-2">Promedios</h2>';
@@ -269,6 +282,20 @@ document.getElementById('runAnova').addEventListener('click', async function() {
             `<td>${c.se.toFixed(4)}</td>` +
             `<td>${c.q_crit.toFixed(4)}</td>` +
             `<td>${c.hsd.toFixed(4)}</td>` +
+            `<td>${c.significant ? 'Significativo' : 'No significativo'}</td></tr>`;
+    });
+    html += '</tbody></table>';
+
+    html += '<h2 class="font-semibold mb-2">Prueba de Duncan</h2>';
+    html += '<table class="min-w-full text-sm text-center mb-4">';
+    html += '<thead><tr><th>Comparaci&oacute;n</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>q cr&iacute;tico</th><th>DMS</th><th>Significativo</th></tr></thead><tbody>';
+    Object.keys(duncan.comparaciones).forEach(key => {
+        const c = duncan.comparaciones[key];
+        html += `<tr><td>${c.grupo1} - ${c.grupo2}</td>` +
+            `<td>${c.diff.toFixed(4)}</td>` +
+            `<td>${c.se.toFixed(4)}</td>` +
+            `<td>${c.q_crit.toFixed(4)}</td>` +
+            `<td>${c.dms.toFixed(4)}</td>` +
             `<td>${c.significant ? 'Significativo' : 'No significativo'}</td></tr>`;
     });
     html += '</tbody></table>';


### PR DESCRIPTION
## Summary
- implement Duncan's multiple range test in `anova.py`
- expose the new `calcular_duncan` function to the frontend
- display Duncan test results in the webpage

## Testing
- `python -m py_compile anova.py`


------
https://chatgpt.com/codex/tasks/task_e_687dbf314648832aa1f82f01b6d0ef3d