### PR TITLE
Fix Tukey/Duncan critical values and show diff

### DIFF
--- a/anova.py
+++ b/anova.py
@@ -159,12 +159,14 @@ def calcular_lsd(observaciones_js, alpha=0.05):
 
     comparaciones = {}
     for g1, g2 in combinations(observaciones.keys(), 2):
-        diff = abs(medias[g1] - medias[g2])
+        diff_muestral = medias[g1] - medias[g2]
+        diff = abs(diff_muestral)
         se = sqrt(cm_error * (1 / n_por_tratamiento[g1] + 1 / n_por_tratamiento[g2]))
         lsd = t_crit * se
         comparaciones[f"{g1}-{g2}"] = {
             'grupo1': g1,
             'grupo2': g2,
+            'diff_muestral': diff_muestral,
             'diff': diff,
             'se': se,
             't_crit': t_crit,
@@ -226,28 +228,20 @@ def calcular_tukey(observaciones_js, alpha=0.05):
         )
 
     k = len(observaciones)
-    try:
-        q_crit = stats.studentized_range.ppf(1 - alpha, k, gl_error)
-        if isnan(q_crit):  # pragma: no cover - sanity check for SciPy result
-            raise ValueError("studentized_range.ppf devolvió NaN")
-    except Exception as exc:  # pragma: no cover - SciPy may raise distintos errores
-        # Como respaldo utilizamos la aproximación basada en la distribución t
-        # cuando SciPy no puede calcular el valor crítico de la distribución
-        # del rango studentizado.
-        q_crit = stats.t.ppf(1 - alpha / 2, gl_error) * sqrt(2)
-        if isnan(q_crit):
-            raise ValueError(
-                f"No se pudo calcular el valor crítico de Tukey: {exc}"
-            ) from exc
+    q_crit = stats.studentized_range.ppf(1 - alpha, k, gl_error)
+    if isnan(q_crit):
+        raise ValueError("studentized_range.ppf devolvió NaN")
 
     comparaciones = {}
     for g1, g2 in combinations(observaciones.keys(), 2):
-        diff = abs(medias[g1] - medias[g2])
+        diff_muestral = medias[g1] - medias[g2]
+        diff = abs(diff_muestral)
         se = sqrt(cm_error / 2 * (1 / n_por_tratamiento[g1] + 1 / n_por_tratamiento[g2]))
         hsd = q_crit * se
         comparaciones[f"{g1}-{g2}"] = {
             'grupo1': g1,
             'grupo2': g2,
+            'diff_muestral': diff_muestral,
             'diff': diff,
             'se': se,
             'q_crit': q_crit,
@@ -305,23 +299,18 @@ def calcular_duncan(observaciones_js, alpha=0.05):
         for j in range(i + 1, len(orden)):
             g1 = orden[i]
             g2 = orden[j]
-            diff = abs(medias[g1] - medias[g2])
+            diff_muestral = medias[g1] - medias[g2]
+            diff = abs(diff_muestral)
             r = j - i + 1
-            try:
-                q_crit = stats.studentized_range.ppf(1 - alpha, r, gl_error)
-                if isnan(q_crit):  # pragma: no cover - sanity check
-                    raise ValueError("studentized_range.ppf devolvió NaN")
-            except Exception as exc:  # pragma: no cover - SciPy may fail
-                q_crit = stats.t.ppf(1 - alpha / 2, gl_error) * sqrt(2)
-                if isnan(q_crit):
-                    raise ValueError(
-                        f"No se pudo calcular el valor crítico de Duncan: {exc}"
-                    ) from exc
+            q_crit = stats.studentized_range.ppf(1 - alpha, r, gl_error)
+            if isnan(q_crit):
+                raise ValueError("studentized_range.ppf devolvió NaN")
             se = sqrt(cm_error / 2 * (1 / n_por_tratamiento[g1] + 1 / n_por_tratamiento[g2]))
             dms = q_crit * se
             comparaciones[f"{g1}-{g2}"] = {
                 'grupo1': g1,
                 'grupo2': g2,
+                'diff_muestral': diff_muestral,
                 'diff': diff,
                 'se': se,
                 'q_crit': q_crit,

--- a/index.html
+++ b/index.html
@@ -260,10 +260,11 @@ document.getElementById('runAnova').addEventListener('click', async function() {
 
     html += '<h2 class="font-semibold mb-2">Prueba LSD</h2>';
     html += '<table class="min-w-full text-sm text-center mb-4">';
-    html += '<thead><tr><th>Comparaci&oacute;n</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>t cr&iacute;tico</th><th>LSD</th><th>Significativo</th></tr></thead><tbody>';
+    html += '<thead><tr><th>Comparaci&oacute;n</th><th>Ȳi - Ȳj</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>t cr&iacute;tico</th><th>LSD</th><th>Significativo</th></tr></thead><tbody>';
     Object.keys(lsd.comparaciones).forEach(key => {
         const c = lsd.comparaciones[key];
         html += `<tr><td>${c.grupo1} - ${c.grupo2}</td>` +
+            `<td>${c.diff_muestral.toFixed(4)}</td>` +
             `<td>${c.diff.toFixed(4)}</td>` +
             `<td>${c.se.toFixed(4)}</td>` +
             `<td>${c.t_crit.toFixed(4)}</td>` +
@@ -274,10 +275,11 @@ document.getElementById('runAnova').addEventListener('click', async function() {
 
     html += '<h2 class="font-semibold mb-2">Prueba de Tukey</h2>';
     html += '<table class="min-w-full text-sm text-center mb-4">';
-    html += '<thead><tr><th>Comparaci&oacute;n</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>q cr&iacute;tico</th><th>HSD</th><th>Significativo</th></tr></thead><tbody>';
+    html += '<thead><tr><th>Comparaci&oacute;n</th><th>Ȳi - Ȳj</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>q cr&iacute;tico</th><th>HSD</th><th>Significativo</th></tr></thead><tbody>';
     Object.keys(tukey.comparaciones).forEach(key => {
         const c = tukey.comparaciones[key];
         html += `<tr><td>${c.grupo1} - ${c.grupo2}</td>` +
+            `<td>${c.diff_muestral.toFixed(4)}</td>` +
             `<td>${c.diff.toFixed(4)}</td>` +
             `<td>${c.se.toFixed(4)}</td>` +
             `<td>${c.q_crit.toFixed(4)}</td>` +
@@ -288,10 +290,11 @@ document.getElementById('runAnova').addEventListener('click', async function() {
 
     html += '<h2 class="font-semibold mb-2">Prueba de Duncan</h2>';
     html += '<table class="min-w-full text-sm text-center mb-4">';
-    html += '<thead><tr><th>Comparaci&oacute;n</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>q cr&iacute;tico</th><th>DMS</th><th>Significativo</th></tr></thead><tbody>';
+    html += '<thead><tr><th>Comparaci&oacute;n</th><th>Ȳi - Ȳj</th><th>|Ȳi - Ȳj|</th><th>SE</th><th>q cr&iacute;tico</th><th>DMS</th><th>Significativo</th></tr></thead><tbody>';
     Object.keys(duncan.comparaciones).forEach(key => {
         const c = duncan.comparaciones[key];
         html += `<tr><td>${c.grupo1} - ${c.grupo2}</td>` +
+            `<td>${c.diff_muestral.toFixed(4)}</td>` +
             `<td>${c.diff.toFixed(4)}</td>` +
             `<td>${c.se.toFixed(4)}</td>` +
             `<td>${c.q_crit.toFixed(4)}</td>` +


### PR DESCRIPTION
## Summary
- compute proper HSD and DMS values using `studentized_range` only
- expose new signed difference `diff_muestral` in Python results
- display this difference in LSD/HSD/DMS tables

## Testing
- `python3 -m py_compile anova.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687dc4827ba0832a93ec0835440f9d0e