### PR TITLE
Add Shapiro-Wilk verification table

### DIFF
--- a/anova.py
+++ b/anova.py
@@ -331,3 +331,23 @@ def calcular_duncan(observaciones_js, alpha=0.05):
     return {
         'comparaciones': comparaciones,
     }
+
+
+def prueba_shapiro(observaciones_js):
+    """Aplica la prueba de Shapiro-Wilk a los residuos del modelo."""
+
+    from scipy import stats
+
+    try:
+        observaciones = observaciones_js.to_py()
+    except AttributeError:
+        observaciones = observaciones_js
+
+    medias = {k: sum(v) / len(v) for k, v in observaciones.items()}
+    residuos = [y - medias[g] for g, vals in observaciones.items() for y in vals]
+
+    stat, p_value = stats.shapiro(residuos)
+    return {
+        'w': stat,
+        'p_value': p_value,
+    }

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -4,6 +4,7 @@ from anova import (
     calcular_lsd,
     calcular_tukey,
     calcular_duncan,
+    prueba_shapiro,
 )
 
 
@@ -13,6 +14,7 @@ def generate_html(groups):
     lsd = calcular_lsd(groups)
     tukey = calcular_tukey(groups)
     duncan = calcular_duncan(groups)
+    shapiro = prueba_shapiro(groups)
 
     html = [
         "<!DOCTYPE html>",
@@ -64,6 +66,12 @@ def generate_html(groups):
         f"<tr><td>Total</td><td>{anova_res['SC_T']:.4f}</td><td>{anova_res['GL_T']}</td><td></td><td></td><td></td></tr>"
     )
     html.append("</tbody></table>")
+
+    html.append("<h2>Prueba de normalidad (Shapiro-Wilk)</h2>")
+    html.append(
+        "<table><thead><tr><th>W</th><th>Valor-p</th></tr></thead>"
+        f"<tbody><tr><td>{shapiro['w']:.4f}</td><td>{shapiro['p_value']:.4f}</td></tr></tbody></table>"
+    )
 
     def comparisons_table(title, res, label):
         html.append(f"<h2>{title}</h2>")


### PR DESCRIPTION
## Summary
- implement `prueba_shapiro` to compute normality test
- render Shapiro-Wilk results in generated HTML

## Testing
- `python run_analysis.py` *(fails: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_687e78f883a8832a8847acc6edfc48a0