### PR TITLE
Fix missing bartlett variable in report

### DIFF
--- a/run_analysis.py
+++ b/run_analysis.py
@@ -126,6 +126,7 @@ def format_text(groups):
     tukey = calcular_tukey(groups)
     duncan = calcular_duncan(groups)
     shapiro = prueba_shapiro(groups)
+    bartlett = prueba_bartlett(groups)
 
     lines = ["MEDIAS POR GRUPO"]
     for g, m in anova_res["group_means"].items():


### PR DESCRIPTION
## Summary
- fix `NameError` for bartlett results in `format_text`

## Testing
- `pip install scipy --user` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_687e9d60b5cc832a9901ab549329ac9c